### PR TITLE
Fix foreign key constraint for default agent (ID: 0)

### DIFF
--- a/alembic/versions/make_agent_id_nullable.py
+++ b/alembic/versions/make_agent_id_nullable.py
@@ -1,0 +1,32 @@
+"""Make agent_id nullable in chat_histories for default agent support
+
+Revision ID: make_agent_id_nullable
+Revises: 
+Create Date: 2025-08-25 07:35:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'make_agent_id_nullable'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Make agent_id nullable in chat_histories table"""
+    # Make agent_id column nullable to support default agent (ID: 0)
+    # which doesn't exist in ai_agents table
+    op.alter_column('chat_histories', 'agent_id',
+                   existing_type=sa.INTEGER(),
+                   nullable=True)
+
+
+def downgrade():
+    """Make agent_id non-nullable again"""
+    op.alter_column('chat_histories', 'agent_id',
+                   existing_type=sa.INTEGER(),
+                   nullable=False)

--- a/app/api/api_v1/endpoints/chat.py
+++ b/app/api/api_v1/endpoints/chat.py
@@ -242,10 +242,12 @@ async def send_message(
         )
 
         # Create new chat history
+        # Use NULL for default agent (ID: 0) to avoid foreign key constraint
+        db_agent_id = None if agent_id == 0 else agent_id
         new_history = ChatHistory(
             church_id=current_user.church_id,
             user_id=current_user.id,
-            agent_id=agent_id,
+            agent_id=db_agent_id,
             title=title_preview,
             is_bookmarked=False,
             message_count=0,

--- a/app/models/ai_agent.py
+++ b/app/models/ai_agent.py
@@ -69,7 +69,7 @@ class ChatHistory(Base):
     id = Column(Integer, primary_key=True, index=True)
     church_id = Column(Integer, ForeignKey("churches.id"), nullable=False)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-    agent_id = Column(Integer, ForeignKey("ai_agents.id"), nullable=False)
+    agent_id = Column(Integer, ForeignKey("ai_agents.id"), nullable=True)
     title = Column(String(255), nullable=False)
     is_bookmarked = Column(Boolean, default=False)
     message_count = Column(Integer, default=0)


### PR DESCRIPTION
- Make agent_id nullable in ChatHistory model
- Store NULL instead of 0 for default agent to avoid FK constraint violation
- Add database migration for agent_id nullable change
- This fixes 500 Internal Server Error when creating chat with default agent

Resolves issue where default agent (ID: 0) caused IntegrityError because it doesn't exist in ai_agents table.

🤖 Generated with [Claude Code](https://claude.ai/code)