### PR TITLE
Fix GPT-5-mini parameter issue: use max_completion_tokens instead of …

### DIFF
--- a/app/services/openai_service.py
+++ b/app/services/openai_service.py
@@ -66,12 +66,24 @@ class OpenAIService:
             logger.debug(f"Calling OpenAI API with model: {normalized_model}")
 
             # Call OpenAI API using the new client
-            response = self.client.chat.completions.create(
-                model=normalized_model,
-                messages=messages,
-                max_tokens=max_tokens,
-                temperature=temperature,
-            )
+            # GPT-5 models use max_completion_tokens instead of max_tokens
+            if normalized_model.startswith("gpt-5"):
+                logger.info(
+                    f"Using max_completion_tokens for GPT-5 model: {max_tokens}"
+                )
+                response = self.client.chat.completions.create(
+                    model=normalized_model,
+                    messages=messages,
+                    max_completion_tokens=max_tokens,
+                    temperature=temperature,
+                )
+            else:
+                response = self.client.chat.completions.create(
+                    model=normalized_model,
+                    messages=messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                )
 
             # Extract response
             content = response.choices[0].message.content
@@ -191,12 +203,21 @@ class OpenAIService:
                 messages = [{"role": "system", "content": system_prompt}] + messages
 
             # Call OpenAI API
-            response = self.client.chat.completions.create(
-                model=model,
-                messages=messages,
-                max_tokens=max_tokens,
-                temperature=temperature,
-            )
+            # GPT-5 models use max_completion_tokens instead of max_tokens
+            if model.startswith("gpt-5"):
+                response = self.client.chat.completions.create(
+                    model=model,
+                    messages=messages,
+                    max_completion_tokens=max_tokens,
+                    temperature=temperature,
+                )
+            else:
+                response = self.client.chat.completions.create(
+                    model=model,
+                    messages=messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                )
 
             # Extract response
             content = response.choices[0].message.content


### PR DESCRIPTION
…max_tokens

- GPT-5 models require max_completion_tokens parameter, not max_tokens
- Add conditional logic to use correct parameter based on model type
- Apply fix to both async and sync generate_response methods
- Add logging for GPT-5 parameter usage

Fixes OpenAI API error:
"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."

🤖 Generated with [Claude Code](https://claude.ai/code)