### PR TITLE
Fix GPT-5-mini temperature constraint: force temperature=1.0

### DIFF
--- a/app/services/openai_service.py
+++ b/app/services/openai_service.py
@@ -66,16 +66,23 @@ class OpenAIService:
             logger.debug(f"Calling OpenAI API with model: {normalized_model}")
 
             # Call OpenAI API using the new client
-            # GPT-5 models use max_completion_tokens instead of max_tokens
+            # GPT-5 models have specific parameter requirements
             if normalized_model.startswith("gpt-5"):
+                # GPT-5 models require specific parameters
+                adjusted_temperature = 1.0  # GPT-5 only supports temperature=1.0
+                if temperature != 1.0:
+                    logger.warning(
+                        f"🔧 GPT-5 Temperature 조정: {temperature} → 1.0 (모델 제약)"
+                    )
+
                 logger.info(
-                    f"Using max_completion_tokens for GPT-5 model: {max_tokens}"
+                    f"Using GPT-5 parameters - max_completion_tokens: {max_tokens}, temperature: 1.0"
                 )
                 response = self.client.chat.completions.create(
                     model=normalized_model,
                     messages=messages,
                     max_completion_tokens=max_tokens,
-                    temperature=temperature,
+                    temperature=adjusted_temperature,
                 )
             else:
                 response = self.client.chat.completions.create(
@@ -203,13 +210,20 @@ class OpenAIService:
                 messages = [{"role": "system", "content": system_prompt}] + messages
 
             # Call OpenAI API
-            # GPT-5 models use max_completion_tokens instead of max_tokens
+            # GPT-5 models have specific parameter requirements
             if model.startswith("gpt-5"):
+                # GPT-5 models require specific parameters
+                adjusted_temperature = 1.0  # GPT-5 only supports temperature=1.0
+                if temperature != 1.0:
+                    logger.warning(
+                        f"🔧 GPT-5 Temperature 조정: {temperature} → 1.0 (모델 제약)"
+                    )
+
                 response = self.client.chat.completions.create(
                     model=model,
                     messages=messages,
                     max_completion_tokens=max_tokens,
-                    temperature=temperature,
+                    temperature=adjusted_temperature,
                 )
             else:
                 response = self.client.chat.completions.create(


### PR DESCRIPTION
- GPT-5 models only support temperature=1.0 (not 0.7 or other values)
- Automatically adjust temperature to 1.0 for GPT-5 models
- Add warning log when temperature is adjusted due to model constraints
- Apply fix to both async and sync generate_response methods

Fixes OpenAI API error:
"Unsupported value: 'temperature' does not support 0.7 with this model. Only the default (1) value is supported."

🤖 Generated with [Claude Code](https://claude.ai/code)