### PR TITLE
Fix CORS settings for sermon-materials API authentication

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -42,11 +42,17 @@ app = FastAPI(
     openapi_url=f"{settings.API_V1_STR}/openapi.json",
 )
 
-# Set up CORS - Allow all origins for development
+# Set up CORS - Allow specific origins for authentication
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # Allow all origins for development
-    allow_credentials=False,  # Set to False when using allow_origins=["*"]
+    allow_origins=[
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+        "https://smart-yoram.vercel.app",
+        "https://smart-yoram-frontend.vercel.app",
+        "https://api.surfmind-team.com"
+    ],
+    allow_credentials=True,  # Enable credentials for authentication
     allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allow_headers=["*"],
     expose_headers=["*"],


### PR DESCRIPTION
## Summary
- Fix CORS policy to allow localhost:3000 and other frontend domains
- Enable credentials for authentication to work properly with Bearer tokens
- Resolve CORS errors when accessing sermon-materials API from frontend

## Changes
- Changed allow_origins from ['*'] to specific allowed origins
- Set allow_credentials=True for authentication
- Added localhost:3000, 127.0.0.1:3000, and production domains

## Testing
- Frontend should now be able to access sermon-materials API without CORS errors
- Bearer token authentication should work properly

🤖 Generated with [Claude Code](https://claude.ai/code)