### PR TITLE
Fix CORS for smart-yoram-admin.vercel.app

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -50,6 +50,7 @@ app.add_middleware(
         "http://127.0.0.1:3000",
         "https://smart-yoram.vercel.app",
         "https://smart-yoram-frontend.vercel.app",
+        "https://smart-yoram-admin.vercel.app",
         "https://api.surfmind-team.com",
     ],
     allow_credentials=True,  # Enable credentials for authentication


### PR DESCRIPTION
## Summary
Add https://smart-yoram-admin.vercel.app to CORS allowed origins

## Problem
Frontend at smart-yoram-admin.vercel.app getting CORS error:
- Access to XMLHttpRequest blocked by CORS policy
- No 'Access-Control-Allow-Origin' header present

## Solution  
Added the admin domain to allow_origins list in CORS middleware

🤖 Generated with [Claude Code](https://claude.ai/code)