### PR TITLE
Fix AI agent templates AttributeError

### DIFF
--- a/app/api/api_v1/endpoints/ai_agents.py
+++ b/app/api/api_v1/endpoints/ai_agents.py
@@ -55,9 +55,9 @@ def read_agent_templates(
                 "system_prompt": template.system_prompt,
                 "icon": template.icon,
                 "config": {
-                    "model": template.model,
-                    "temperature": template.temperature,
-                    "max_tokens": template.max_tokens,
+                    "model": "gpt-4o-mini",  # Default model for templates
+                    "temperature": 0.7,     # Default temperature
+                    "max_tokens": 4000,     # Default max tokens
                 },
             }
         )


### PR DESCRIPTION
## Problem
AI agents endpoint throwing AttributeError:


## Root Cause
The  endpoint was trying to access , , and  fields that don't exist in the  model.

## Solution  
- Replace with default values for templates
- Use  as default model
- Set temperature to 0.7 and max_tokens to 4000

🤖 Generated with [Claude Code](https://claude.ai/code)