### PR TITLE
Fix CORS preflight for sermon-materials API

### DIFF
--- a/app/api/api_v1/endpoints/sermon_materials.py
+++ b/app/api/api_v1/endpoints/sermon_materials.py
@@ -533,3 +533,21 @@ def run_sermon_materials_migration(db: Session = Depends(deps.get_db)) -> Any:
             "error": str(e),
             "timestamp": "2025-08-26T12:55:00Z",
         }
+
+
+@router.options("/")
+@router.options("/{path:path}")
+def handle_options():
+    """
+    Handle OPTIONS requests for CORS preflight
+    """
+    from fastapi import Response
+    return Response(
+        status_code=200,
+        headers={
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+            "Access-Control-Allow-Headers": "*",
+            "Access-Control-Allow-Credentials": "true",
+        }
+    )


### PR DESCRIPTION
## Problem
sermon-materials API was returning 405 Method Not Allowed for OPTIONS requests, causing CORS preflight failures.

## Root Cause  
FastAPI sermon-materials router didn't have explicit OPTIONS handlers, so preflight requests were rejected.

## Solution
- Added @router.options handlers for / and /{path:path} 
- Returns 200 OK with proper CORS headers
- Allows preflight requests to succeed

## Testing
After deployment:
```bash
curl -X OPTIONS 'https://api.surfmind-team.com/api/v1/sermon-materials/'   -H 'Origin: http://localhost:3000'
```
Should return 200 OK instead of 405.

🤖 Generated with [Claude Code](https://claude.ai/code)