### PR TITLE
Fix secretary agent always retrieving fresh church data

### DIFF
--- a/app/api/api_v1/endpoints/chat.py
+++ b/app/api/api_v1/endpoints/chat.py
@@ -519,11 +519,15 @@ async def send_message(
             logger.info(f"🔍 Debug - prioritize_church_data: {getattr(chat_request, 'prioritize_church_data', None)}")
             logger.info(f"🔍 Debug - agent.church_data_sources: {agent.church_data_sources}")
             
+            # 비서 에이전트는 항상 최신 데이터 조회, 일반 에이전트는 기존 로직 유지
+            is_secretary_mode = getattr(chat_request, 'secretary_mode', False)
+            logger.info(f"🔍 Debug - is_secretary_mode: {is_secretary_mode}")
             should_get_church_data = (
-                not church_data_context
+                (not church_data_context or is_secretary_mode)  # 비서 모드에서는 하드코딩된 컨텍스트 무시
                 and chat_request.prioritize_church_data
                 and agent.church_data_sources
             )
+            logger.info(f"🔍 Debug - should_get_church_data: {should_get_church_data}")
             
             if should_get_church_data:
                 logger.info(f"📊 Retrieving church data for agent {agent.id}")


### PR DESCRIPTION
- 비서 에이전트는 하드코딩된 church_data_context를 무시하고 항상 최신 DB 데이터 조회
- is_secretary_mode일 때 should_get_church_data = true 강제 설정
- 추가 디버깅 로그로 secretary_mode 및 should_get_church_data 상태 추적
- 운영환경에서 100명 하드코딩 대신 실제 83명 DB 데이터 반환 예상

🤖 Generated with [Claude Code](https://claude.ai/code)