### PR TITLE
Fix announcement API issues: CORS, 500 errors, and model imports

### DIFF
--- a/alembic/versions/add_announcement_multi_target_support.py
+++ b/alembic/versions/add_announcement_multi_target_support.py
@@ -20,9 +20,16 @@ def upgrade():
     
     # Add target_type column to announcements
     try:
-        op.add_column('announcements', sa.Column('target_type', sa.String(50), nullable=False, server_default='single'))
+        op.add_column('announcements', sa.Column('target_type', sa.String(50), nullable=False, server_default='all'))
     except Exception as e:
         print(f"Column addition failed (may already exist): {e}")
+    
+    # Update existing system announcements to use 'all' target_type
+    try:
+        op.execute("UPDATE announcements SET target_type = 'all' WHERE type = 'system' AND church_id IS NULL")
+        op.execute("UPDATE announcements SET target_type = 'single' WHERE type = 'church' AND church_id IS NOT NULL")
+    except Exception as e:
+        print(f"Data update failed: {e}")
     
     # Create announcement_targets table for multi-target support
     try:

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -8,7 +8,7 @@ from .qr_code import QRCode
 from .calendar_event import CalendarEvent
 from .notification import Notification
 from .family_relationship import FamilyRelationship
-from .announcement import Announcement
+from .announcement import Announcement, AnnouncementRead, AnnouncementTarget
 from .daily_verse import DailyVerse
 from .worship_schedule import WorshipService, WorshipServiceCategory
 from .push_notification import (

--- a/app/models/announcement.py
+++ b/app/models/announcement.py
@@ -20,7 +20,7 @@ class Announcement(Base):
     priority = Column(String(50), nullable=False, default='normal')  # 'urgent', 'important', 'normal'
     
     # 대상 설정: 'all' (전체), 'specific' (특정 교회들), 'single' (단일 교회)
-    target_type = Column(String(50), nullable=False, default='single')
+    target_type = Column(String(50), nullable=False, default='all')
     
     # 명세서 요구사항: 기간 설정
     start_date = Column(Date, nullable=False)
@@ -36,7 +36,7 @@ class Announcement(Base):
     is_pinned = Column(Boolean, default=False)  # Pin important announcements
 
     # Category fields (기존 기능 유지)
-    category = Column(String, nullable=False)  # worship, member_news, event
+    category = Column(String, nullable=False, default='system')  # worship, member_news, event, system
     subcategory = Column(String)  # Optional subcategory
 
     # Target audience (기존 기능 유지)

--- a/app/schemas/announcement.py
+++ b/app/schemas/announcement.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 class AnnouncementBase(BaseModel):
     title: str
     content: str
-    category: str  # worship, member_news, event
+    category: Optional[str] = "system"  # worship, member_news, event, system
     subcategory: Optional[str] = None
     priority: Optional[str] = "normal"  # urgent, important, normal
     target_type: Optional[str] = "all"  # all, specific, single


### PR DESCRIPTION
- Add AnnouncementRead and AnnouncementTarget to models __init__.py
- Update migration to set proper default values for target_type
- Add exception handling to admin endpoints with detailed error messages
- Fix Church model field access issues in churches endpoint
- Set proper defaults for category and target_type fields
- Simplify member_count calculation to prevent attribute errors
- Update announcement schema to use optional category field

Fixes:
• 500 Internal Server Error in GET /api/v1/announcements/admin • Missing model imports causing import errors
• Church model attribute access issues
• Database field default value problems

🤖 Generated with [Claude Code](https://claude.ai/code)