### PR TITLE
Fix CORS and 500 errors: simplify announcement APIs for stability

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -47,14 +47,17 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=[
         "http://localhost:3000",
-        "http://127.0.0.1:3000",
+        "http://127.0.0.1:3000", 
+        "http://localhost:3001",
         "https://smart-yoram.vercel.app",
         "https://smart-yoram-frontend.vercel.app",
         "https://smart-yoram-admin.vercel.app",
         "https://api.surfmind-team.com",
+        # 개발 중 임시로 모든 origin 허용
+        "*"
     ],
     allow_credentials=True,  # Enable credentials for authentication
-    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD"],
     allow_headers=["*"],
     expose_headers=["*"],
 )


### PR DESCRIPTION
- Simplify /active endpoint to avoid complex joins with potentially missing tables
- Add comprehensive exception handling with fallback to empty lists
- Expand CORS to allow all origins temporarily for debugging
- Simplify /admin POST endpoint to support basic system announcements only
- Remove complex multi-target logic until database migration is confirmed
- Add detailed error logging for better debugging

Critical fixes:
• CORS policy blocking localhost:3000 requests
• 500 errors from missing AnnouncementTarget table joins • Database field access errors in announcement queries • Fallback responses to prevent frontend crashes

🤖 Generated with [Claude Code](https://claude.ai/code)