### PR TITLE
Fix database column errors: revert to existing table structure

### DIFF
--- a/app/schemas/announcement.py
+++ b/app/schemas/announcement.py
@@ -8,18 +8,13 @@ class AnnouncementBase(BaseModel):
     content: str
     category: Optional[str] = "system"  # worship, member_news, event, system
     subcategory: Optional[str] = None
-    priority: Optional[str] = "normal"  # urgent, important, normal
-    target_type: Optional[str] = "all"  # all, specific, single
-    start_date: date
-    end_date: Optional[date] = None
     is_active: Optional[bool] = True
     is_pinned: Optional[bool] = False
     target_audience: Optional[str] = "all"
 
 
 class AnnouncementCreate(AnnouncementBase):
-    church_id: Optional[int] = None  # single target용
-    target_church_ids: Optional[List[int]] = []  # specific targets용
+    pass
 
 
 class AnnouncementUpdate(AnnouncementBase):
@@ -27,21 +22,13 @@ class AnnouncementUpdate(AnnouncementBase):
     content: Optional[str] = None
     category: Optional[str] = None
     subcategory: Optional[str] = None
-    priority: Optional[str] = None
-    target_type: Optional[str] = None
-    start_date: Optional[date] = None
-    end_date: Optional[date] = None
-    target_church_ids: Optional[List[int]] = []
 
 
 class AnnouncementInDBBase(AnnouncementBase):
     id: int
     church_id: Optional[int] = None
-    type: str  # system, church
-    target_type: str  # all, specific, single
     author_id: int
     author_name: Optional[str] = None
-    created_by: int
     created_at: datetime
     updated_at: Optional[datetime] = None
 


### PR DESCRIPTION
- Remove references to non-existent columns: type, priority, target_type, start_date, end_date, created_by
- Simplify announcement APIs to work with current database schema
- Update announcement schemas to match existing table structure
- Fix active announcements query to use basic church_id filtering
- Simplify announcement creation to use only existing fields
- Remove complex multi-target logic that requires new tables

Database compatibility:
• Works with existing announcements table structure • No migration required for immediate functionality • Simple system announcements (church_id = NULL)
• Basic church-specific announcements (church_id = user.church_id)

🤖 Generated with [Claude Code](https://claude.ai/code)